### PR TITLE
after_success部分にlabel貼り自動化を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,20 @@ language: bash
 
 script: true
 
-after_success: ./merge.sh $GIT_USER $GIT_PASS
+after_success:
+  #!/bin/bash
+OWNER=elmas3
+REPO=pull-request-practice
+# CI で設定される NUMBER を環境変数からとる
+NUMBER=1
+LABEL=MergeCat
+# GITHUB_TOKEN に token をセットしてあるものとする
+
+curl -XPOST \
+  -d "[\"$LABEL\"]" \
+  -H 'Accept: application/vnd.github.v3+json' \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$NUMBER/labels
 
 env:
   global:


### PR DESCRIPTION
# 自動マージについて🌱
<a href="https://gyazo.com/416761e05663436b57875d579b6c3405"><img src="https://i.gyazo.com/416761e05663436b57875d579b6c3405.gif" alt="https://gyazo.com/416761e05663436b57875d579b6c3405" width="960"/></a>
プルリクを作ったら、右メニューの「label」からピンク色の`MeargeCat`を選択してください。
自動でマージされます🙌

# ご注意🌱

GitHubの公開リポジトリを使った実践は、すべてGitHub上に公開され、誰でも閲覧できる状態になります。
つまり、コミットに含まれるあなたのユーザー名・メールアドレスは、pushするとインターネット上に公開されます。
このPull Requestがマージされると、あなたの情報が本レポジトリに取り込まれるため、あなた自身で削除することができなくなります。

個人情報を公開したくない方は、本Pull Requestをキャンセルして、ご自身のリポジトリを一度削除お願いします。

その後、
SourceTreeの[設定]アイコン　＞　[高度な設定]タブ（Windowsの場合は[詳細]タブ）　＞　[ユーザー情報]欄の

・名前をニックネームに
・メールアドレスを、自分のアカウント名@users.noreply.github.com に

変更してから、p107〜p156の実践を始めてください。

`プルリクエスト送信時は、このメッセージを上書きしてもらって構いません♪`
